### PR TITLE
forward the current plugin prefix to graphiql

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -78,7 +78,7 @@ internals.graphqlHandler = function (request, reply) {
 internals.graphiqlHandler = function (request, reply) {
   const query = request.query;
   const variables = query.variables || '{}';
-  const { prefix = '' } = request.route.realm.modifiers.route;
+  const prefix = request.route.realm.modifiers.route.prefix || '';
 
   reply(Graphiql.renderGraphiQL({
     endpointURL: prefix + this.settings.graphqlPath,

--- a/lib/index.js
+++ b/lib/index.js
@@ -78,11 +78,13 @@ internals.graphqlHandler = function (request, reply) {
 internals.graphiqlHandler = function (request, reply) {
   const query = request.query;
   const variables = query.variables || '{}';
+  const { prefix = '' } = request.route.realm.modifiers.route;
 
   reply(Graphiql.renderGraphiQL({
-    endpointURL: this.settings.graphqlPath,
+    endpointURL: prefix + this.settings.graphqlPath,
     query: query.query,
     variables: JSON.parse(variables),
     operationName: query.operationName
   }));
 };
+


### PR DESCRIPTION
I was in a situation where the prefix was applied to the */graph** routes but not given to graphiql =)