### PR TITLE
Support hapi authStrategies

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ hapi GraphQL server plugin
 - `graphiqlPath` - HTTP path to serve the GraphiQL UI. Set to '' or false to disable. Default is `/graphiql`
 - `schema` - graphql schema either as a string or as a GraphQLSchema instance
 - `resolvers` - query and mutation functions mapped to their respective keys. Resolvers should return a promise when performing asynchronous operations.
+- `authStrategy` - (optional) Authentication strategy to apply to `./graphql` route.  Default is `false`. 
 
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ hapi GraphQL server plugin
 - `graphiqlPath` - HTTP path to serve the GraphiQL UI. Set to '' or false to disable. Default is `/graphiql`
 - `schema` - graphql schema either as a string or as a GraphQLSchema instance
 - `resolvers` - query and mutation functions mapped to their respective keys. Resolvers should return a promise when performing asynchronous operations.
-- `authStrategy` - (optional) Authentication strategy to apply to `./graphql` route.  Default is `false`. 
+- `authStrategy` - (optional) Authentication strategy to apply to `/graphql` route.  Default is `false`. 
 
 
 ## Usage

--- a/example.js
+++ b/example.js
@@ -45,6 +45,7 @@ internals.init()
   .then((server) => {
     console.log('server.info.uri ' + server.info.uri);
     // open http://localhost:8000/graphiql?query=%7B%20person(firstname%3A%20%22billy%22)%20%7B%20lastname%20%7D%20%7D&variables=%7B%7D
+    // curl -X POST -H "Content-Type: application/json" -d '{"query":"{person(firstname:\"billy\"){lastname}}"}' http://127.0.0.1:8000/graphql
   })
   .catch((error) => {
     console.log('Error: ' + error);

--- a/example.js
+++ b/example.js
@@ -3,6 +3,8 @@
 const Hapi = require('hapi');
 const Graphi = require('.');
 
+const internals = {};
+
 const schema = `
   type Person {
     firstname: String!
@@ -24,21 +26,26 @@ const resolvers = {
   person: getPerson
 };
 
-const server = new Hapi.Server();
-server.connection({ port: 8000 });
-server.register({ register: Graphi, options: { schema, resolvers } }, (err) => {
-  if (err) {
-    console.error(err);
-    process.exit(1);
+
+internals.init = async () => {
+  try {
+    const server = new Hapi.Server({ port: 8000 });
+
+    await server.register({ plugin: Graphi, options: { schema, resolvers } });
+
+    await server.start();
+
+    return server;
+  } catch (err) {
+    throw err;
   }
+};
 
-  server.start((err) => {
-    if (err) {
-      console.error(err);
-      process.exit(1);
-    }
-
-    console.log('server started at localhost:8000');
+internals.init()
+  .then((server) => {
+    console.log('server.info.uri ' + server.info.uri);
     // open http://localhost:8000/graphiql?query=%7B%20person(firstname%3A%20%22billy%22)%20%7B%20lastname%20%7D%20%7D&variables=%7B%7D
+  })
+  .catch((error) => {
+    console.log('Error: ' + error);
   });
-});

--- a/lib/index.js
+++ b/lib/index.js
@@ -9,7 +9,8 @@ const Package = require('../package.json');
 const internals = {
   defaults: {
     graphqlPath: '/graphql',
-    graphiqlPath: '/graphiql'
+    graphiqlPath: '/graphiql',
+    authStrategy: false
   }
 };
 
@@ -30,14 +31,18 @@ exports.register = function (server, options) {
   server.bind({ schema, resolvers, settings });
 
   const tags = ['graphql'];
-  server.route({
+
+  const route = {
     method: '*',
     path: settings.graphqlPath,
     config: {
       tags,
+      auth: settings.authStrategy,
       handler: internals.graphqlHandler
     }
-  });
+  };
+
+  server.route(route);
 
   if (settings.graphiqlPath) {
     server.route({
@@ -45,6 +50,7 @@ exports.register = function (server, options) {
       path: settings.graphiqlPath,
       config: {
         tags,
+        auth: false,
         handler: internals.graphiqlHandler
       }
     });

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "belly-button": "4.x.x",
     "code": "5.x.x",
     "hapi": "17.x.x",
+    "hapi-auth-bearer-token": "^6.0.1",
     "lab": "15.x.x",
     "scalars": "0.x.x"
   },


### PR DESCRIPTION
* Updated example.js for hapi v17
* Added support for hapi authStrategies.
  See Issue #7 for details about authStrategies.
* My graphi repo [here](https://github.com/zoe-1/graphi)