### PR TITLE
Add tracing

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ hapi GraphQL server plugin
 - `authStrategy` - (optional) Authentication strategy to apply to `/graphql` route.  Default is `false`.
 - `graphiAuthStrategy` - (optional) Authentication strategy to apply to `/graphiql` route.  Default is `false`.
 - `formatError` - (optional) Function that receives a [GraphQLError](https://github.com/graphql/graphql-js/blob/271e23e13ec093e7ffb844e7ffaf340ab92f053e/src/error/GraphQLError.js) as its only argument and returns a custom error object, which is returned to the client.
+- `tracing` - (optional) Display on the console timing information around the GraphQL resolver. Default is `false`.
 
 ## API
 

--- a/example.js
+++ b/example.js
@@ -31,7 +31,7 @@ internals.init = async () => {
   try {
     const server = new Hapi.Server({ port: 8000 });
 
-    await server.register({ plugin: Graphi, options: { schema, resolvers } });
+    await server.register({ plugin: Graphi, options: { schema, resolvers, tracing: true } });
 
     await server.start();
 

--- a/example.js
+++ b/example.js
@@ -31,7 +31,7 @@ internals.init = async () => {
   try {
     const server = new Hapi.Server({ port: 8000 });
 
-    await server.register({ plugin: Graphi, options: { schema, resolvers, tracing: true } });
+    await server.register({ plugin: Graphi, options: { schema, resolvers } });
 
     await server.start();
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -91,7 +91,7 @@ internals.registerSchema = function ({ schema = {}, resolvers = {} }) {
 internals.onPreStart = function (server) {
   const resolver = ({ prefix = '', method = 'graphql' }) => {
     return async (payload, request, ast) => {
-      const url = `${prefix}/${ast.fieldName}`;
+      const url = `${prefix}/${ast.fieldName}`;info.fieldName;
       const res = await request.server.inject({
         method,
         url,
@@ -237,6 +237,7 @@ internals.fieldResolver = function (request) {
 
     const tracerResult = {};
     if (tracing) {
+      tracerResult.fieldName = info.fieldName;
       tracerResult.path = [...Graphql.responsePathAsArray(info.path)];
       tracerResult.parentType = info.parentType;
       tracerResult.returnType = info.returnType;

--- a/lib/index.js
+++ b/lib/index.js
@@ -208,7 +208,10 @@ internals.graphqlHandler = async function (request, h) {
         ]);
       });
 
-    console.log(table.toString());
+    if (tracingResult.tracingResolvers.length > 0) {
+      console.log(table.toString());
+    }
+
     tracingResult.tracingResolvers = [];
   }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -14,13 +14,22 @@ const internals = {
     graphiqlPath: '/graphiql',
     authStrategy: false,
     graphiAuthStrategy: false,
-    formatError: null
+    formatError: null,
+    tracing: false,
+    tracingResult: {
+      startTime: 0,
+      endTime: 0,
+      duration: 0,
+      tracingResolvers: []
+    }
   }
 };
 
 
 exports.register = function (server, options) {
   const settings = Merge({}, internals.defaults, options);
+
+  settings.tracingResult.startTime = internals.duration(process.hrtime());
 
   server.expose('resolvers', {});
   server.expose('settings', settings);
@@ -163,7 +172,7 @@ internals.graphqlHandler = async function (request, h) {
     return Boom.badRequest(errors.join(', '));
   }
 
-  const result = await Graphql.execute(schema, queryAST, resolvers, request, variables, operationName);
+  const result = await Graphql.execute(schema, queryAST, resolvers, request, variables, operationName, internals.fieldResolver(request));
   if (result.errors) {
     const formatError = request.server.plugins.graphi.settings.formatError;
     if (typeof formatError === 'function') {
@@ -179,6 +188,18 @@ internals.graphqlHandler = async function (request, h) {
 
   if (span) {
     span.finish();
+  }
+
+  const { tracing, tracingResult } = request.server.plugins.graphi.settings;
+
+  if (tracing) {
+    tracingResult.endTime = internals.duration(process.hrtime());
+    tracingResult.duration = tracingResult.endTime - tracingResult.startTime;
+    tracingResult.tracingResolvers = tracingResult.tracingResolvers.map((tracingResolver) => {
+      return { ...tracingResolver, duration: tracingResolver.endTime - tracingResolver.startTime };
+    });
+
+    // TODO: Display the tracing result.
   }
 
   return result;
@@ -208,4 +229,32 @@ internals.tryParseVariables = function (input) {
   } catch (error) {
     return Boom.badRequest('Unable to JSON.parse variables', error);
   }
+};
+
+internals.fieldResolver = function (request) {
+  return function (value, args, ctx, info) {
+    const { tracing, tracingResult } = request.server.plugins.graphi.settings;
+
+    const tracerResult = {};
+    if (tracing) {
+      tracerResult.path = [...Graphql.responsePathAsArray(info.path)];
+      tracerResult.parentType = info.parentType;
+      tracerResult.returnType = info.returnType;
+      tracerResult.startTime = internals.duration(process.hrtime());
+
+      tracingResult.tracingResolvers.push(tracerResult);
+    }
+
+    const result = Graphql.defaultFieldResolver(value, args, ctx, info);
+
+    if (tracing) {
+      tracerResult.endTime = internals.duration(process.hrtime());
+    }
+
+    return result;
+  };
+};
+
+internals.duration = function (hrtime) {
+  return hrtime[0] * 1e9 + hrtime[1];
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -208,10 +208,7 @@ internals.graphqlHandler = async function (request, h) {
         ]);
       });
 
-    if (tracingResult.tracingResolvers.length) {
-      console.log(table.toString());
-    }
-
+    console.log(table.toString());
     tracingResult.tracingResolvers = [];
   }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,6 +4,7 @@ const Boom = require('boom');
 const Graphql = require('graphql');
 const Graphiql = require('apollo-server-module-graphiql');
 const Merge = require('lodash.merge');
+const Table = require('cli-table');
 const Utils = require('./utils');
 const Package = require('../package.json');
 
@@ -17,9 +18,6 @@ const internals = {
     formatError: null,
     tracing: false,
     tracingResult: {
-      startTime: 0,
-      endTime: 0,
-      duration: 0,
       tracingResolvers: []
     }
   }
@@ -28,8 +26,6 @@ const internals = {
 
 exports.register = function (server, options) {
   const settings = Merge({}, internals.defaults, options);
-
-  settings.tracingResult.startTime = internals.duration(process.hrtime());
 
   server.expose('resolvers', {});
   server.expose('settings', settings);
@@ -91,7 +87,7 @@ internals.registerSchema = function ({ schema = {}, resolvers = {} }) {
 internals.onPreStart = function (server) {
   const resolver = ({ prefix = '', method = 'graphql' }) => {
     return async (payload, request, ast) => {
-      const url = `${prefix}/${ast.fieldName}`;info.fieldName;
+      const url = `${prefix}/${ast.fieldName}`;
       const res = await request.server.inject({
         method,
         url,
@@ -126,6 +122,8 @@ internals.onPreStart = function (server) {
 };
 
 internals.graphqlHandler = async function (request, h) {
+  const { tracing, tracingResult } = request.server.plugins.graphi.settings;
+
   if (request.method.toUpperCase() === 'OPTIONS') {
     return h.continue;
   }
@@ -190,16 +188,29 @@ internals.graphqlHandler = async function (request, h) {
     span.finish();
   }
 
-  const { tracing, tracingResult } = request.server.plugins.graphi.settings;
-
   if (tracing) {
-    tracingResult.endTime = internals.duration(process.hrtime());
-    tracingResult.duration = tracingResult.endTime - tracingResult.startTime;
-    tracingResult.tracingResolvers = tracingResult.tracingResolvers.map((tracingResolver) => {
-      return { ...tracingResolver, duration: tracingResolver.endTime - tracingResolver.startTime };
+    const table = new Table({
+      head: ['Field name', 'Parent Type', 'Return Type', 'Path', 'Duration (ns)', 'Duration (ms)']
     });
 
-    // TODO: Display the tracing result.
+    tracingResult.tracingResolvers.forEach((tracingResolver) => {
+      const duration = tracingResolver.endTime - tracingResolver.startTime;
+
+      table.push([
+        tracingResolver.fieldName,
+        tracingResolver.parentType,
+        tracingResolver.returnType,
+        tracingResolver.path.join(' - '),
+        duration,
+        duration / 1e6
+      ]);
+    });
+
+    if (tracingResult.tracingResolvers.length) {
+      console.log(table.toString());
+    }
+
+    tracingResult.tracingResolvers = [];
   }
 
   return result;

--- a/lib/index.js
+++ b/lib/index.js
@@ -193,18 +193,20 @@ internals.graphqlHandler = async function (request, h) {
       head: ['Field name', 'Parent Type', 'Return Type', 'Path', 'Duration (ns)', 'Duration (ms)']
     });
 
-    tracingResult.tracingResolvers.forEach((tracingResolver) => {
-      const duration = tracingResolver.endTime - tracingResolver.startTime;
-
-      table.push([
-        tracingResolver.fieldName,
-        tracingResolver.parentType,
-        tracingResolver.returnType,
-        tracingResolver.path.join(' - '),
-        duration,
-        duration / 1e6
-      ]);
-    });
+    tracingResult.tracingResolvers
+      .sort((a, b) => {
+        return a.duration - b.duration;
+      })
+      .forEach((tracingResolver) => {
+        table.push([
+          tracingResolver.fieldName,
+          tracingResolver.parentType,
+          tracingResolver.returnType,
+          tracingResolver.path.join(' - '),
+          tracingResolver.duration,
+          tracingResolver.duration / 1e6
+        ]);
+      });
 
     if (tracingResult.tracingResolvers.length) {
       console.log(table.toString());
@@ -260,7 +262,8 @@ internals.fieldResolver = function (request) {
     const result = Graphql.defaultFieldResolver(value, args, ctx, info);
 
     if (tracing) {
-      tracerResult.endTime = internals.duration(process.hrtime());
+      const endTime = internals.duration(process.hrtime());
+      tracerResult.duration = endTime - tracerResult.startTime;
     }
 
     return result;

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "apollo-server-module-graphiql": "1.4.x",
     "boom": "7.x.x",
-    "cli-table": "^0.3.1",
+    "cli-table": "^0.3.x",
     "graphql": "14.1.x",
     "graphql-tools": "4.0.x",
     "lodash.merge": "4.6.x"

--- a/package.json
+++ b/package.json
@@ -37,9 +37,10 @@
     "wreck": "14.x.x"
   },
   "dependencies": {
-    "boom": "7.x.x",
-    "graphql": "14.1.x",
     "apollo-server-module-graphiql": "1.4.x",
+    "boom": "7.x.x",
+    "cli-table": "^0.3.1",
+    "graphql": "14.1.x",
     "graphql-tools": "4.0.x",
     "lodash.merge": "4.6.x"
   }

--- a/test/index.js
+++ b/test/index.js
@@ -1820,6 +1820,48 @@ describe('server.registerSchema()', () => {
       expect(res.statusCode).to.equal(200);
       expect(res.result.data.person.lastname).to.equal('jean');
     });
+
+    it('will not show a blank table when there are no requests', async () => {
+      const schema = `
+        type Person {
+          firstname: String!
+          lastname: String!
+          email: String!
+        }
+
+        type Query {
+          person(firstname: String!): Person!
+        }
+      `;
+
+      const getPerson = function (args, request) {
+        expect(args.firstname).to.equal('billy');
+        expect(request.path).to.equal('/graphql');
+        return { firstname: '', lastname: 'jean', email: 'what' };
+      };
+
+      const resolvers = {
+        person: getPerson
+      };
+
+      let output = '';
+      const originalStdout = process.stdout.write;
+      process.stdout.write = (data) => {
+        output += data.toString();
+      };
+
+      const server = Hapi.server();
+      await server.register({ plugin: Graphi, options: { schema, resolvers, tracing: true } });
+      await server.initialize();
+
+      const res = await server.inject({ method: 'GET', url: '/graphiql' });
+      process.stdout.write = originalStdout;
+
+      expect(output).to.not.include('Duration');
+      expect(output).to.not.include('person - email');
+      expect(output).to.not.include('Query');
+      expect(res.statusCode).to.equal(200);
+    });
   });
 });
 


### PR DESCRIPTION
The idea is to have a tracer on the fields of the operation, before landing it, I have few questions...

### Questions:

+ Shall we have startTime and endTime? do you think those are in the right place?
+ How we should display the tracing result?

### Missing: 

- [x] UT
- [x] Update documentation

### Result
```
{
  "startTime": 42511540659488,
  "endTime": 42515156653108,
  "duration": 3615993620,
  "tracingResolvers": [
    {
      "path": ["person"],
      "parentType": "Query",
      "returnType": "Person!",
      "startTime": 42515155683053,
      "endTime": 42515155770657,
      "duration": 87604
    },
    {
      "path": ["person", "firstname"],
      "parentType": "Person",
      "returnType": "String!",
      "startTime": 42515156403990,
      "endTime": 42515156411814,
      "duration": 7824
    },
    {
      "path": ["person", "lastname"],
      "parentType": "Person",
      "returnType": "String!",
      "startTime": 42515156578296,
      "endTime": 42515156580820,
      "duration": 2524
    }
  ]
}
```

I think for the moment that is it!

Thanks