### PR TITLE
update dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: node_js
 
 node_js:
-  - "8"
-  - "10"
+  - "12"
   - "node"
 
 sudo: false

--- a/example.js
+++ b/example.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const Hapi = require('hapi');
+const Hapi = require('@hapi/hapi');
 const Graphi = require('.');
 
 const internals = {};
@@ -28,17 +28,13 @@ const resolvers = {
 
 
 internals.init = async () => {
-  try {
-    const server = new Hapi.Server({ port: 8000 });
+  const server = new Hapi.Server({ port: 8000 });
 
-    await server.register({ plugin: Graphi, options: { schema, resolvers } });
+  await server.register({ plugin: Graphi, options: { schema, resolvers } });
 
-    await server.start();
+  await server.start();
 
-    return server;
-  } catch (err) {
-    throw err;
-  }
+  return server;
 };
 
 internals.init()

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const Boom = require('boom');
+const Boom = require('@hapi/boom');
 const Graphql = require('graphql');
 const Graphiql = require('apollo-server-module-graphiql');
 const Merge = require('lodash.merge');
@@ -112,7 +112,7 @@ internals.onPreStart = function (server) {
         return res.result;
       }
 
-      return new Boom(res.result.message, {
+      return new Boom.Boom(res.result.message, {
         statusCode: res.statusCode,
         data: {
           error: res.result.error,

--- a/package.json
+++ b/package.json
@@ -25,20 +25,20 @@
   },
   "homepage": "https://github.com/geek/graphi#readme",
   "devDependencies": {
-    "belly-button": "5.x.x",
-    "cb-barrier": "1.0.x",
-    "code": "5.x.x",
-    "hapi": "18.x.x",
+    "belly-button": "6.x.x",
+    "cb-barrier": "1.x.x",
+    "@hapi/code": "8.x.x",
+    "@hapi/hapi": "19.x.x",
     "hapi-auth-bearer-token": "6.x.x",
-    "lab": "18.x.x",
-    "nes": "10.0.x",
-    "opentracing": "0.14.3",
-    "traci": "1.4.0",
-    "wreck": "14.x.x"
+    "@hapi/lab": "22.x.x",
+    "@hapi/nes": "11.x.x",
+    "opentracing": "0.14.x",
+    "traci": "2.x.x",
+    "@hapi/wreck": "17.x.x"
   },
   "dependencies": {
-    "boom": "7.x.x",
-    "graphql": "14.1.x",
+    "@hapi/boom": "9.x.x",
+    "graphql": "14.5.x",
     "apollo-server-module-graphiql": "1.4.x",
     "lodash.merge": "4.6.x"
   }

--- a/test/index.js
+++ b/test/index.js
@@ -1,23 +1,21 @@
 'use strict';
 
 const Barrier = require('cb-barrier');
-const Code = require('code');
+const Code = require('@hapi/code');
 const GraphQL = require('graphql');
-const Hapi = require('hapi');
+const Hapi = require('@hapi/hapi');
 const HapiAuthBearerToken = require('hapi-auth-bearer-token');
-const Lab = require('lab');
-const Nes = require('nes');
+const Lab = require('@hapi/lab');
+const Nes = require('@hapi/nes');
 const { MockTracer } = require('opentracing');
 const Traci = require('traci');
-const Wreck = require('wreck');
+const Wreck = require('@hapi/wreck');
 const Graphi = require('../');
 
 
 // Test shortcuts
 
-const lab = exports.lab = Lab.script();
-const describe = lab.describe;
-const it = lab.it;
+const { describe, it } = exports.lab = Lab.script();
 const expect = Code.expect;
 
 
@@ -1351,7 +1349,7 @@ describe('graphi', () => {
     await server.initialize();
 
     const res = await server.inject({ method: 'OPTIONS', url: '/graphql' });
-    expect(res.statusCode).to.equal(200);
+    expect(res.statusCode).to.equal(204);
   });
 
 

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,18 +1,16 @@
 'use strict';
 
-const Code = require('code');
+const Code = require('@hapi/code');
 const GraphQL = require('graphql');
-const Hapi = require('hapi');
-const Lab = require('lab');
+const Hapi = require('@hapi/hapi');
+const Lab = require('@hapi/lab');
 const Graphi = require('../');
 const Utils = require('../lib/utils');
 
 
 // Test shortcuts
 
-const lab = exports.lab = Lab.script();
-const describe = lab.describe;
-const it = lab.it;
+const { describe, it } = exports.lab = Lab.script();
 const expect = Code.expect;
 
 


### PR DESCRIPTION
This PR updates to the latest version of all dependencies. A few notes:

- hapi 19 dropped support for Node < 12, so the Travis file is updated.
- hapi now sends back a 204 for empty responses instead of 200.
- The `example.js` file had a useless `try...catch`, which belly-button now flags.
- `new Boom()` has been replaced by `new Boom.Boom()` in the boom module.

This will require publishing a new major version.