### PR TITLE
Set version range of graphql to 16.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@hapi/boom": "10.x.x",
-    "graphql": "16.6.x",
+    "graphql": "16.x.x",
     "apollo-server-module-graphiql": "1.4.x",
     "lodash.merge": "4.6.x"
   }


### PR DESCRIPTION
As discussed in #36, the rather strict version range of the `graphql` dependency creates interoperability issues with other packages and tools that depend on `graphql`.

Loosening this version should improve the interoperability with other modules.